### PR TITLE
fix: JIRA API concurrent request limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # JIRA Miner ![CI](https://github.com/kpiwko/jira-miner/workflows/CI/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/kpiwko/jira-miner/badge.svg?branch=main)](https://coveralls.io/github/kpiwko/jira-miner?branch=main)
 
-A tool to gather data from JIRA and query them locally for better speed and more flexible query language than jql. The tool stores
-entries available in JIRA locally in [Loki.js](http://lokijs.org) database in a file. This means the tool has no dependency but Node.js
+A tool to gather data from JIRA and query them locally for better speed and more flexible query language than jql. The tool stores entries available in JIRA locally in [Loki.js](http://lokijs.org) database in a file. This means the tool has no dependency but Node.js.
 
 ## Usage
 
 The tool is intended to act both as command line tool or a library in other projects. In order to be able to effectively query something,
 you need to populate the database first. Afterwards, you can query content of the database pretty easily.
 
-You can install the tool by
+You can install the tool by running
 ```
 npm install -g jira-miner
 ```
@@ -38,14 +37,14 @@ Once, you have targeted a jira, you can populate local database
 jira-miner populate <jqlQuery>
 ```
 
-EXAMPLE: `jira-miner populate "project in (AEROGAR, ARQ)"` downloads all issues (including their history) for projects AGPUSH and ARQ)
+**EXAMPLE**: `jira-miner populate "project in (AEROGAR, ARQ)"` downloads all issues (including their history) for projects AGPUSH and ARQ)
 
 If you rerun the query, it will rewrite all updated items. It might be a good idea to update the database since the last query to limit
 the amount of fetched data. You can do that via `--since` argument that accepts a timestamp.
 
 TIP: For very large queries, you might run out of memory. You can increase memory of node process and reduce GC calls via following:
 ```
-node --max_old_space_size=4096 --nouse-idle-notification dist/index.js populate
+npx -n "--max-old-space-size=4096" jira-miner populate
 ```
 
 ### Query the database
@@ -53,8 +52,8 @@ node --max_old_space_size=4096 --nouse-idle-notification dist/index.js populate
 JIRA miner provides an API to query the database. Query must be defined in one of following formats:
 
 ```TypeScript
-import { HistoryCollection } from 'jira-miner/dist/lib/db/LocalJiraDB'
-import { QueryResult } from 'jira-miner/dist/lib/db/Query'
+import { HistoryCollection } from 'jira-miner/lib/db/LocalJiraDB'
+import { QueryResult } from 'jira-miner/lib/db/Query'
 
 
 export async function query(collection: HistoryCollection<any>, args?: object): Promise<any> {
@@ -78,7 +77,9 @@ All arguments passed on command line will be available in args object. Example q
 
 ### Debug output
 
-Simply run any command with `--verbose` parameter. You can provide it twice (e.g. `-vv`) to have further level of debug output
+Simply run any command with `--verbose` parameter. You can provide it twice (e.g. `-vv`) to have further level of debug output.
+
+You can also setup environment variable `DEBUG` to include `jira-miner` value to get the equivalent of verbose logging.
 
 ### Image rendering example
 
@@ -87,7 +88,7 @@ For entries that have optional `link` attribute provided, it will additionally r
 
 ```TypeScript
 
-import TimeLineChart from 'jira-miner/dist/lib/chart/TimeLineChart'
+import TimeLineChart from 'jira-miner/lib/chart/TimeLineChart'
 
 export async function query(collection: HistoryCollection<any>, args?: object): Promise<any> {
 
@@ -114,7 +115,7 @@ You provide the mapping by `labels` options during chart creation.
 
 ```TypeScript
 
-import TimeAreaChart from 'jira-miner/dist/lib/chart/TimeAreaChart'
+import TimeAreaChart from 'jira-miner/lib/chart/TimeAreaChart'
 
 export async function query(collection: HistoryCollection<any>, args?: object): Promise<any> {
 
@@ -144,17 +145,17 @@ All charts are rendered as either png, svg or json
 Prerequisites:
 
 ```
-npm install -g typescript ava nyc ts-node
+npm install -g ava typescript nyc coveralls
 ```
 
-Afterwards, you can run tests via following command:
+Afterwards, you can run tests via following commands:
 
 ```
 npm run test
 ```
 
 
-Code coverage (via nyc tool):
+Code coverage (via `nyc` tool):
 ```
 npm run coverage
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -444,6 +444,17 @@
           "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
+          },
+          "dependencies": {
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            }
           }
         },
         "path-exists": {
@@ -3159,6 +3170,17 @@
           "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
+          },
+          "dependencies": {
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            }
           }
         },
         "path-exists": {
@@ -4290,6 +4312,17 @@
           "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
+          },
+          "dependencies": {
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            }
           }
         },
         "p-map": {
@@ -4597,12 +4630,11 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "requires": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^0.1.0"
       }
     },
     "p-locate": {
@@ -4612,6 +4644,17 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        }
       }
     },
     "p-map": {
@@ -4905,6 +4948,17 @@
           "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
+          },
+          "dependencies": {
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            }
           }
         },
         "path-exists": {
@@ -6531,6 +6585,11 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-miner",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An utility for advanced queryies on top of JIRA",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -47,6 +47,7 @@
     "jsonfile": "^2.4.0",
     "lokijs": "^1.5.11",
     "moment": "^2.29.1",
+    "p-limit": "^3.1.0",
     "prettyjson": "^1.2.1",
     "promise-request-retry": "^1.0.1",
     "promise-retry": "^1.1.1",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -14,7 +14,7 @@ export default class Logger {
     else {
       this.logger = winston.createLogger({
         transports: [
-          new winston.transports.Console({ level: process.env.DEBUG ? 'debug' : 'info' })
+          new winston.transports.Console({ level: process.env.DEBUG && process.env.DEBUG.includes('jira-miner') ? 'debug' : 'info' })
         ]
       })
       Logger.instance = this  

--- a/src/tests/jira/JiraClient.ts
+++ b/src/tests/jira/JiraClient.ts
@@ -2,7 +2,7 @@
 
 import test from 'ava'
 import { RequestPromiseAPI } from 'request-promise-native'
-import * as sinon from 'sinon'
+import sinon from 'sinon'
 import JiraClient from '../../jira/JiraClient'
 
 test('Log to JIRA without user', async t => {
@@ -75,7 +75,7 @@ test('Exercise JIRA check credentials logic', async t => {
 
 const jira = new JiraClient({ url: 'https://issues.redhat.com' })
 
-test('Fetch issue with summary field', async t => {
+test('Fetch issues with summary field', async t => {
   const issues = await jira.fetch('project = SEAM', { fields: ['summary'] })
   t.assert(issues.length > 0, 'SEAM issues have been fetched')
   t.truthy(issues[0]['Summary'], 'Summary is available on the first issue')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,6 @@
 import moment from 'moment'
 import _ from 'lodash'
 
-export const TRANSFORMATION_CHUNK_SIZE = 10
-
 /**
  * Executes all promises in parallel and unifies the data to a single array.
  * Allows a transformation of result returned by each of the promise to a format/object
@@ -12,15 +10,8 @@ export const TRANSFORMATION_CHUNK_SIZE = 10
  * @returns an array of objects of type R
  */
 export async function transformAll<T, R>(transform: (o: T) => R, promises: Promise<T>[]): Promise<R[]> {
-
-  // limit transformation 10 parallel requests at maximum
-  // forEach loop does not wait of resolution of a promise
-  const results: any[] = []
-  for await (const promisesSlice of _.chunk(promises, TRANSFORMATION_CHUNK_SIZE)) {
-    const slice = await Promise.all(promisesSlice)
-    results.push(...slice)
-  }
-
+  const results = await Promise.all(promises)
+  
   return results.reduce((acc: R[], sublist: T) => {
     return acc.concat(transform(sublist))
   }, [])


### PR DESCRIPTION
Fixed Promise execution so that they are not triggered at the same time. Previous attempt to fix it was limiting processing the responses, not number of requests fired.