### PR TITLE
fix!: reducer are now able to consider both priority and severity

### DIFF
--- a/src/metric/Metric.ts
+++ b/src/metric/Metric.ts
@@ -194,7 +194,7 @@ export const statusPriorityReducer = (): MetricReduce => {
       metadata: [...link(mapResult)],
       values: [
         ...countBy(mapResult, 'Status'),
-        ...countBy(mapResult, 'Priority'),
+        ...countBy(mapResult, (i) => i['Priority'] ?? i['Severity']),
         {
           id: 'total',
           value: mapResult.length,
@@ -211,7 +211,7 @@ export const trendReducer = (trend: string): MetricReduce => {
       metadata: [...link(mapResult)],
       values: [
         ...countBy(mapResult, 'Status'),
-        ...countBy(mapResult, 'Priority'),
+        ...countBy(mapResult, (i) => i['Priority'] ?? i['Severity']),
         {
           id: trend,
           value: mapResult.length,

--- a/src/tests/fixtures/fixtures.ts
+++ b/src/tests/fixtures/fixtures.ts
@@ -19,13 +19,13 @@ export const schemaFixture: JiraSchema = {
 
 export type Malformation<T> = (data: T[]) => T[]
 
-export async function dbFixture({
+export const dbFixture = async ({
   malformation = (data) => data,
   source = '../fixtures/aerogear200issues.json',
 }: {
   malformation?: Malformation<IssueJson>
   source?: string
-}): Promise<HistoryCollection> {
+}): Promise<HistoryCollection> => {
   const dbpath = tmp.fileSync()
   const testDB = await JiraDBFactory.localInstance(dbpath.name)
 
@@ -40,4 +40,60 @@ export async function dbFixture({
   })
 
   return await testDB.populate('aerogear200issues', issues)
+}
+
+export const issuesFixture = ({ malformation = (data) => data }: { malformation?: Malformation<Issue> }): Issue[] => {
+  const issueData: Issue[] = [
+    {
+      id: 'issue-1',
+      key: 'ISSUE-1',
+      self: 'https://issues.org/browse/ISSUE-1',
+      History: [],
+      Priority: 'Major',
+      Status: 'Resolved',
+    },
+    {
+      id: 'issue-2',
+      key: 'ISSUE-2',
+      self: 'https://issues.org/browse/ISSUE-2',
+      History: [],
+      Priority: 'Major',
+      Status: 'Unresolved',
+    },
+    {
+      id: 'issue-3',
+      key: 'ISSUE-3',
+      self: 'https://issues.org/browse/ISSUE-3',
+      History: [],
+      Priority: 'Minor',
+      Status: 'Done',
+    },
+    {
+      id: 'issuesev-4',
+      key: 'ISSUESEV-4',
+      self: 'https://issues.org/browse/ISSUESEV-4',
+      History: [],
+      Severity: 'Minor',
+      Status: 'Done',
+    },
+    {
+      id: 'issuesev-5',
+      key: 'ISSUESEV-5',
+      self: 'https://issues.org/browse/ISSUESEV-5',
+      History: [],
+      Severity: 'Urgent',
+      Status: 'Resolved',
+    },
+    {
+      id: 'issueprisev-5',
+      key: 'ISSUEPRISEV-5',
+      self: 'https://issues.org/browse/ISSUEPRISEV-5',
+      History: [],
+      Priority: 'Blocker',
+      Severity: 'Urgent',
+      Status: 'Obsolete',
+    },
+  ]
+
+  return malformation(issueData)
 }

--- a/src/tests/metric/Metric.ts
+++ b/src/tests/metric/Metric.ts
@@ -1,0 +1,28 @@
+import test from 'ava'
+import { MetricResults, statusPriorityReducer, trendReducer } from '../../metric/Metric'
+import { issuesFixture } from '../fixtures/fixtures'
+
+const getValue = (results: MetricResults, key: string): number | undefined => {
+  const value = results.values.find((m) => m.id === key)
+  return value?.value
+}
+
+test('Status Priority Reducer', (t) => {
+  const results = statusPriorityReducer()('2021-03-17', issuesFixture({}))
+  t.is(getValue(results, 'Major'), 2)
+  t.is(getValue(results, 'Minor'), 2)
+  t.is(getValue(results, 'Urgent'), 1)
+  t.is(getValue(results, 'Blocker'), 1)
+  t.is(getValue(results, 'Resolved'), 2)
+  t.is(getValue(results, 'Obsolete'), 1)
+})
+
+test('Trend Reducer', (t) => {
+  const results = trendReducer('Arrival Trend')('2021-03-17', issuesFixture({}))
+  t.is(getValue(results, 'Major'), 2)
+  t.is(getValue(results, 'Minor'), 2)
+  t.is(getValue(results, 'Urgent'), 1)
+  t.is(getValue(results, 'Resolved'), 2)
+  t.is(getValue(results, 'Obsolete'), 1)
+  t.is(getValue(results, 'Arrival Trend'), 6)
+})


### PR DESCRIPTION
In case priority for an issue is not defined, severity is used